### PR TITLE
Adding unprocessed option to write_shifts_from_results

### DIFF
--- a/audalign/__init__.py
+++ b/audalign/__init__.py
@@ -587,7 +587,12 @@ def get_metadata(file_path: str):
     return mediainfo(filepath=file_path)
 
 
-def write_shifted_file(file_path: str, destination_path: str, offset_seconds: float):
+def write_shifted_file(
+    file_path: str,
+    destination_path: str,
+    offset_seconds: float,
+    unprocessed: bool = False,
+):
     """
     Writes file to destination_path with specified shift in seconds
 
@@ -596,8 +601,11 @@ def write_shifted_file(file_path: str, destination_path: str, offset_seconds: fl
         file_path (str): file path of file to shift
         destination_path (str): where to write file to and file name
         offset_seconds (float): how many seconds to shift, can't be negative
+        unprocessed (bool): If true, writes files without processing.
     """
-    filehandler.shift_write_file(file_path, destination_path, offset_seconds)
+    filehandler.shift_write_file(
+        file_path, destination_path, offset_seconds, unprocessed=unprocessed
+    )
 
 
 def write_shifts_from_results(

--- a/audalign/__init__.py
+++ b/audalign/__init__.py
@@ -548,6 +548,7 @@ def _write_shifted_files(
     names_and_paths: dict,
     write_extension: str,
     write_multi_channel: bool = False,
+    unprocessed: bool = False,
 ):
     """
     Writes files to destination_path with specified shift
@@ -558,6 +559,7 @@ def _write_shifted_files(
         destination_path (str): folder to write file to
         names_and_paths (dict{str}): dict with name as key and path as value
         write_multi_channel (bool): If true, only write out combined file with each input audio file being one channel. If false, write out shifted files separately and total combined file
+        unprocessed (bool): If true, writes files without processing. For total files, only doesn't normalize
     """
     filehandler.shift_write_files(
         files_shifts,
@@ -565,6 +567,7 @@ def _write_shifted_files(
         names_and_paths,
         write_extension,
         write_multi_channel=write_multi_channel,
+        unprocessed=unprocessed,
     )
 
 
@@ -599,13 +602,14 @@ def write_shifted_file(file_path: str, destination_path: str, offset_seconds: fl
 
 def write_shifts_from_results(
     results: dict,
-    read_from_dir,
     destination_path: str,
+    read_from_dir: str = None,
     write_extension: str = None,
     write_multi_channel: bool = False,
+    unprocessed: bool = False,
 ):
     """
-    For writing the results of an alignment with alternate source files.
+    For writing the results of an alignment with alternate source files or unprocessed files
     Especially useful if you want to align the original files with the results from noise
     removed or uniform leveled versions.
 
@@ -620,6 +624,7 @@ def write_shifts_from_results(
         destination_path (str): destination to write to.
         write_extension (str, optional): if given, all files writen with given extension
         write_multi_channel (bool): If true, only write out combined file with each input audio file being one channel. If false, write out shifted files separately and total combined file
+        unprocessed (bool): If true, writes files without processing. For total files, only doesn't normalize
     """
     if isinstance(read_from_dir, str):
         print("Finding audio files")
@@ -660,6 +665,7 @@ def write_shifts_from_results(
             names_and_paths,
             write_extension,
             write_multi_channel=write_multi_channel,
+            unprocessed=unprocessed,
         )
     except PermissionError:
         print("Permission Denied for write fine_align")

--- a/audalign/filehandler.py
+++ b/audalign/filehandler.py
@@ -796,11 +796,12 @@ def _shift_write_multichannel(
             total_files.export(file_place, format=os.path.splitext(total_name)[1][1:])
 
 
-def shift_write_file(file_path, destination_path, offset_seconds):
-    silence = AudioSegment.silent(
-        offset_seconds * 1000, frame_rate=BaseConfig.sample_rate
-    )
-    audiofile = create_audiosegment(file_path)
+def shift_write_file(
+    file_path, destination_path, offset_seconds, unprocessed: bool = False
+):
+    audiofile = create_audiosegment(file_path, unprocessed=unprocessed)
+    sample_rate: int = audiofile.frame_rate
+    silence = AudioSegment.silent(offset_seconds * 1000, frame_rate=sample_rate)
     audiofile = silence + audiofile
     with open(destination_path, "wb") as file_place:
         audiofile.export(file_place, format=os.path.splitext(destination_path)[1][1:])

--- a/audalign/filehandler.py
+++ b/audalign/filehandler.py
@@ -56,6 +56,7 @@ def create_audiosegment(
     start_end: tuple = None,
     sample_rate=BaseConfig.sample_rate,
     length=None,
+    unprocessed=False,
 ) -> AudioSegment:
     if sample_rate is None:
         sample_rate = BaseConfig.sample_rate
@@ -68,10 +69,13 @@ def create_audiosegment(
             audiofile = AudioSegment.silent(duration=0, frame_rate=sample_rate)
         else:
             audiofile = AudioSegment.silent(duration=length, frame_rate=sample_rate)
-    audiofile = audiofile.set_frame_rate(sample_rate)
-    audiofile = audiofile.set_sample_width(2)
-    audiofile = audiofile.set_channels(1)
-    audiofile = effects.normalize(audiofile)
+    if not unprocessed:
+        audiofile = audiofile.set_frame_rate(sample_rate)
+        audiofile = audiofile.set_sample_width(2)
+        audiofile = audiofile.set_channels(1)
+        audiofile = effects.normalize(audiofile)
+    else:
+        sample_rate = audiofile.frame_rate
     if start_end is not None:
 
         # Does the preprocessing and bounds checking
@@ -548,6 +552,7 @@ def shift_write_files(
     names_and_paths: dict,
     write_extension: str,
     write_multi_channel: bool = False,
+    unprocessed: bool = False,
 ):
     """
     Args
@@ -557,6 +562,7 @@ def shift_write_files(
         names_and_paths (dict{str}): dict with name as key and path as value
         write_extension (str): if given, writes all alignments with given extension (ex. ".wav" or "wav")
         write_multi_channel (bool): If true, only write out combined file with each input audio file being one channel. If false, write out shifted files separately and total combined file
+        unprocessed (bool): If true, writes files without processing
     """
     _shift_files(
         files_shifts,
@@ -565,6 +571,7 @@ def shift_write_files(
         write_extension,
         write_multi_channel=write_multi_channel,
         return_files=False,
+        unprocessed=unprocessed,
     )
 
 
@@ -576,6 +583,7 @@ def _shift_files(
     write_multi_channel: bool = False,
     sample_rate: int = None,
     return_files: bool = False,
+    unprocessed: bool = False,
 ):
     if sample_rate is None:
         sample_rate = BaseConfig.sample_rate
@@ -592,6 +600,7 @@ def _shift_files(
             write_extension,
             sample_rate=sample_rate,
             return_files=return_files,
+            unprocessed=unprocessed,
         )
     else:
         return _shift_write_multichannel(
@@ -601,6 +610,7 @@ def _shift_files(
             write_extension,
             sample_rate=sample_rate,
             return_files=return_files,
+            unprocessed=unprocessed,
         )
 
 
@@ -611,12 +621,14 @@ def _shift_write_separate(
     write_extension: typing.Optional[str],
     sample_rate: int = None,
     return_files: bool = False,
+    unprocessed: bool = False,
 ):
     audsegs = _shift_prepend_space_audsegs(
         files_shifts=files_shifts,
         names_and_paths=names_and_paths,
         sample_rate=sample_rate,
         return_files=return_files,
+        unprocessed=unprocessed,
     )
     if return_files:
         return audsegs
@@ -629,6 +641,15 @@ def _shift_write_separate(
         )
 
     audsegs = list(audsegs.values())
+
+    if unprocessed:
+        # Still have to guarantee they'll combine for total file
+        # No normalization
+        for i, audseg in enumerate(audsegs):
+            audseg = audseg.set_frame_rate(sample_rate)
+            audseg = audseg.set_sample_width(2)
+            audseg = audseg.set_channels(1)
+            audsegs[i] = audseg
 
     # adds silence to end of tracks to make them equally long for total
     longest_bytes = max(len(audseg._data) for audseg in audsegs)
@@ -668,6 +689,7 @@ def _shift_prepend_space_audsegs(
     names_and_paths: dict,
     sample_rate: int,
     return_files: bool = False,
+    unprocessed: bool = False,
 ):
     audsegs = {}
     for name in files_shifts.keys():
@@ -675,10 +697,17 @@ def _shift_prepend_space_audsegs(
         if return_files:
             audsegs[file_path] = files_shifts[name]
         else:
+            audiofile = create_audiosegment(
+                file_path, sample_rate=sample_rate, unprocessed=unprocessed
+            )
+            if unprocessed:
+                sample_rate = audiofile.frame_rate
             silence = AudioSegment.silent(
                 (files_shifts[name]) * 1000, frame_rate=sample_rate
             )
-            audiofile = create_audiosegment(file_path, sample_rate=sample_rate)
+            audiofile = create_audiosegment(
+                file_path, sample_rate=sample_rate, unprocessed=unprocessed
+            )
             audiofile: AudioSegment = silence + audiofile
             audsegs[file_path] = audiofile
     return audsegs
@@ -723,15 +752,25 @@ def _shift_write_multichannel(
     write_extension: typing.Optional[str],
     sample_rate: int,
     return_files: bool = False,
+    unprocessed: bool = False,
 ):
     audsegs = _shift_prepend_space_audsegs(
         files_shifts=files_shifts,
         names_and_paths=names_and_paths,
         sample_rate=sample_rate,
         return_files=return_files,
+        unprocessed=unprocessed,
     )
     if return_files:
         return audsegs
+    if unprocessed:
+        # Still have to guarantee they'll combine for total file
+        # No normalization
+        for file_name, audseg in audsegs.items():
+            audseg = audseg.set_frame_rate(sample_rate)
+            audseg = audseg.set_sample_width(2)
+            audseg = audseg.set_channels(1)
+            audsegs[file_name] = audseg
     # sorts channels by filename
     audsegs = [x[1] for x in sorted(list(audsegs.items()))]
     # adds silence to end of tracks to make them equally long for total

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -403,16 +403,16 @@ class TestRecalcWriteShifts:
         assert temp_results is not None
 
     def test_write_from_results(self, tmpdir):
-        ad.write_shifts_from_results(self.full_results, test_folder_eig, tmpdir)
+        ad.write_shifts_from_results(self.full_results, tmpdir, test_folder_eig)
         ad.write_shifts_from_results(
-            self.full_results, test_folder_eig, tmpdir, write_extension=".mp3"
+            self.full_results, tmpdir, test_folder_eig, write_extension=".mp3"
         )
 
         # sources from original file location
         ad.write_shifts_from_results(
-            self.full_results, None, tmpdir, write_extension=".mp3"
+            self.full_results, tmpdir, None, write_extension=".mp3"
         )
 
         ad.write_shifts_from_results(
-            self.full_results, "no errors just prints", tmpdir, write_extension=".mp3"
+            self.full_results, tmpdir, "no errors just prints", write_extension=".mp3"
         )

--- a/tests/test_audalign.py
+++ b/tests/test_audalign.py
@@ -1,6 +1,8 @@
+import os
+import pickle
+
 import audalign as ad
 import pytest
-import os
 
 
 def test_always_true():
@@ -101,6 +103,9 @@ class TestFingerprinter:
 class TestFilehandler:
 
     test_file = "test_audio/testers/test.mp3"
+    with open("tests/align_test.pickle", "rb") as f:
+        align_fing_results = pickle.load(f)
+    align_fing_results = ad.recalc_shifts(align_fing_results)
 
     def test_read(self):
         array, _ = ad.filehandler.read(self.test_file, sample_rate=None)
@@ -112,6 +117,22 @@ class TestFilehandler:
 
     def test_write_shifted_file(self, tmpdir):
         ad.write_shifted_file(self.test_file, tmpdir.join("place.mp3"), 5)
+
+    def test_write_shifts_from_results(self, tmpdir):
+        ad.write_shifts_from_results(self.align_fing_results, tmpdir)
+
+    def test_write_shifts_from_results_unprocessed(self, tmpdir):
+        ad.write_shifts_from_results(self.align_fing_results, tmpdir, unprocessed=True)
+
+    def test_write_shifts_from_results_multi_channel(self, tmpdir):
+        ad.write_shifts_from_results(
+            self.align_fing_results, tmpdir, write_multi_channel=True
+        )
+
+    def test_write_shifts_from_results_multi_channel_unprocessed(self, tmpdir):
+        ad.write_shifts_from_results(
+            self.align_fing_results, tmpdir, write_multi_channel=True, unprocessed=True
+        )
 
 
 class TestUniformLevel:

--- a/tests/test_audalign.py
+++ b/tests/test_audalign.py
@@ -118,6 +118,11 @@ class TestFilehandler:
     def test_write_shifted_file(self, tmpdir):
         ad.write_shifted_file(self.test_file, tmpdir.join("place.mp3"), 5)
 
+    def test_write_shifted_file_unprocessed(self, tmpdir):
+        ad.write_shifted_file(
+            self.test_file, tmpdir.join("place.mp3"), 5, unprocessed=True
+        )
+
     def test_write_shifts_from_results(self, tmpdir):
         ad.write_shifts_from_results(self.align_fing_results, tmpdir)
 


### PR DESCRIPTION
Allows writing the results of an alignment without normalizing or changing the sample rate or sample width.
The total file is only not normalized before merging