### PR TITLE
Adding normalize field in BaseConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.2.2] 2023 - 02 -05
+
+### Added
+
+- normalize option in BaseConfig, Turns off all normalization if False
+
 ## [1.2.1] 2023 - 01 - 08
 
 ### Changed

--- a/audalign/__init__.py
+++ b/audalign/__init__.py
@@ -24,8 +24,9 @@ import audalign.filehandler as filehandler
 from audalign.config import BaseConfig
 from audalign.recognizers import BaseRecognizer
 from audalign.recognizers.correcognize import CorrelationRecognizer
-from audalign.recognizers.correcognizeSpectrogram import \
-    CorrelationSpectrogramRecognizer
+from audalign.recognizers.correcognizeSpectrogram import (
+    CorrelationSpectrogramRecognizer,
+)
 from audalign.recognizers.fingerprint import FingerprintRecognizer
 from audalign.recognizers.visrecognize import VisualRecognizer
 
@@ -224,11 +225,15 @@ def fine_align(
             strength_stat=recognizer.config.CONFIDENCE,
         )
         paths_audio = filehandler.shift_get_files(
-            recalc_shifts_results, sample_rate=recognizer.config.sample_rate
+            recalc_shifts_results,
+            sample_rate=recognizer.config.sample_rate,
+            normalize=recognizer.config.normalize,
         )
     else:
         paths_audio = filehandler.shift_get_files(
-            results, sample_rate=recognizer.config.sample_rate
+            results,
+            sample_rate=recognizer.config.sample_rate,
+            normalize=recognizer.config.normalize,
         )
 
     max_lags_not_set = False
@@ -265,6 +270,7 @@ def fine_align(
                 new_results["names_and_paths"],
                 write_extension,
                 write_multi_channel=write_multi_channel,
+                normalize=recognizer.config.normalize,
             )
         except PermissionError:
             print("Permission Denied for write fine_align")
@@ -280,6 +286,7 @@ def write_processed_file(
     destination_file: str,
     start_end: tuple = None,
     sample_rate: int = BaseConfig.sample_rate,
+    normalize: bool = BaseConfig.normalize,
 ) -> None:
     """
     writes given file to the destination file after processing for fingerprinting
@@ -290,13 +297,14 @@ def write_processed_file(
         destination_file (str): file path and name to write file to
         start_end (tuple(float, float), optional): Silences before and after start and end. (0, -1) Silences last second, (5.4, 0) silences first 5.4 seconds
         sample_rate (int): sample rate to write file to
-
+        normalize (bool): if true, normalizes file when read
     """
     filehandler.read(
         filename=file_path,
         wrdestination=destination_file,
         start_end=start_end,
         sample_rate=sample_rate,
+        normalize=normalize,
     )
 
 
@@ -549,6 +557,7 @@ def _write_shifted_files(
     write_extension: str,
     write_multi_channel: bool = False,
     unprocessed: bool = False,
+    normalize: bool = BaseConfig.normalize,
 ):
     """
     Writes files to destination_path with specified shift
@@ -560,6 +569,7 @@ def _write_shifted_files(
         names_and_paths (dict{str}): dict with name as key and path as value
         write_multi_channel (bool): If true, only write out combined file with each input audio file being one channel. If false, write out shifted files separately and total combined file
         unprocessed (bool): If true, writes files without processing. For total files, only doesn't normalize
+        normalize (bool): if true, normalizes file when read
     """
     filehandler.shift_write_files(
         files_shifts,
@@ -568,6 +578,7 @@ def _write_shifted_files(
         write_extension,
         write_multi_channel=write_multi_channel,
         unprocessed=unprocessed,
+        normalize=normalize,
     )
 
 
@@ -592,6 +603,7 @@ def write_shifted_file(
     destination_path: str,
     offset_seconds: float,
     unprocessed: bool = False,
+    normalize: bool = BaseConfig.normalize,
 ):
     """
     Writes file to destination_path with specified shift in seconds
@@ -602,9 +614,14 @@ def write_shifted_file(
         destination_path (str): where to write file to and file name
         offset_seconds (float): how many seconds to shift, can't be negative
         unprocessed (bool): If true, writes files without processing.
+        normalize (bool): if true, normalizes file when read
     """
     filehandler.shift_write_file(
-        file_path, destination_path, offset_seconds, unprocessed=unprocessed
+        file_path,
+        destination_path,
+        offset_seconds,
+        unprocessed=unprocessed,
+        normalize=normalize,
     )
 
 
@@ -615,6 +632,7 @@ def write_shifts_from_results(
     write_extension: str = None,
     write_multi_channel: bool = False,
     unprocessed: bool = False,
+    normalize: bool = BaseConfig.normalize,
 ):
     """
     For writing the results of an alignment with alternate source files or unprocessed files
@@ -633,6 +651,7 @@ def write_shifts_from_results(
         write_extension (str, optional): if given, all files writen with given extension
         write_multi_channel (bool): If true, only write out combined file with each input audio file being one channel. If false, write out shifted files separately and total combined file
         unprocessed (bool): If true, writes files without processing. For total files, only doesn't normalize
+        normalize (bool): if true, normalizes file when read
     """
     if isinstance(read_from_dir, str):
         print("Finding audio files")
@@ -674,6 +693,7 @@ def write_shifts_from_results(
             write_extension,
             write_multi_channel=write_multi_channel,
             unprocessed=unprocessed,
+            normalize=normalize,
         )
     except PermissionError:
         print("Permission Denied for write fine_align")
@@ -684,6 +704,7 @@ def convert_audio_file(
     destination_path: str,
     start_end: tuple = None,
     sample_rate: int = None,
+    normalize: bool = BaseConfig.normalize,
 ):
     """
     Convert audio file to type specified in destination path
@@ -694,12 +715,14 @@ def convert_audio_file(
         destination_path (str): where to write file to and file name
         start_end (tuple(float, float), optional): Silences before and after start and end. (0, -1) Silences last second, (5.4, 0) silences first 5.4 seconds
         sample_rate (int): sample rate to write file to
+        normalize (bool): if true, normalizes file when read
     """
     filehandler.read(
         filename=file_path,
         wrdestination=destination_path,
         start_end=start_end,
         sample_rate=sample_rate,
+        normalize=normalize,
     )
 
 

--- a/audalign/config/__init__.py
+++ b/audalign/config/__init__.py
@@ -34,6 +34,9 @@ class BaseConfig(ABC):
     # Decodes audio file to this sample rate
     sample_rate = 44100
 
+    # if true, normalizes all files when read
+    normalize = True
+
     # keys in results dictionaries
     CONFIDENCE = "confidence"
     MATCH_TIME = "match_time"

--- a/audalign/filehandler.py
+++ b/audalign/filehandler.py
@@ -152,8 +152,7 @@ def read(
     wrdestination=None,
     start_end: tuple = None,
     sample_rate=BaseConfig.sample_rate,
-    normalize: bool = BaseConfig.normalize
-    # Root
+    normalize: bool = BaseConfig.normalize,
 ):
     """
     Reads any file supported by pydub (ffmpeg) and returns a numpy array and the bit depth

--- a/audalign/recognizers/correcognize/correcognize.py
+++ b/audalign/recognizers/correcognize/correcognize.py
@@ -65,6 +65,7 @@ def correcognize(
         sample_rate=config.sample_rate,
         _file_audsegs=None,
         sos=sos,
+        normalize=config.normalize,
     )
     against_array = get_array(
         against_file_path,
@@ -72,6 +73,7 @@ def correcognize(
         sample_rate=config.sample_rate,
         _file_audsegs=None,
         sos=sos,
+        normalize=config.normalize,
     )
 
     t = time.time()
@@ -144,6 +146,7 @@ def correcognize_directory(
             sample_rate=config.sample_rate,
             _file_audsegs=_file_audsegs,
             sos=sos,
+            normalize=config.normalize,
         )
         target_file_path = (target_file_path, target_array)
 
@@ -296,6 +299,7 @@ def _correcognize_dir(
             sample_rate=config.sample_rate,
             _file_audsegs=_file_audsegs,
             sos=sos_filter,
+            normalize=config.normalize,
         )
     else:
         target_file_path, target_array = target_file_path
@@ -311,6 +315,7 @@ def _correcognize_dir(
             sample_rate=config.sample_rate,
             _file_audsegs=_file_audsegs,
             sos=sos_filter,
+            normalize=config.normalize,
         )
         return _correcognize(
             target_array=target_array,
@@ -337,15 +342,19 @@ def get_array(
     sample_rate,
     _file_audsegs,
     sos,
+    normalize: bool,
 ):
     if _file_audsegs is not None:
         target_array = get_shifted_file(
             file_path,
             _file_audsegs[file_path],
             sample_rate=sample_rate,
+            normalize=normalize,
         )
     else:
-        target_array = read(file_path, start_end=start_end, sample_rate=sample_rate)[0]
+        target_array = read(
+            file_path, start_end=start_end, sample_rate=sample_rate, normalize=normalize
+        )[0]
     if sos is not None:
         target_array = signal.sosfilt(sos, target_array)
     return target_array

--- a/audalign/recognizers/correcognizeSpectrogram/correcognize_spectrogram.py
+++ b/audalign/recognizers/correcognizeSpectrogram/correcognize_spectrogram.py
@@ -356,7 +356,10 @@ def get_array(
         )
     else:
         target_array = read(
-            file_path, start_end=start_end, sample_rate=config.sample_rate
+            file_path,
+            start_end=start_end,
+            sample_rate=config.sample_rate,
+            normalize=config.normalize,
         )[0]
     if sos is not None:
         target_array = signal.sosfilt(sos, target_array)

--- a/audalign/recognizers/fingerprint/fingerprinter.py
+++ b/audalign/recognizers/fingerprint/fingerprinter.py
@@ -5,8 +5,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from audalign.config.fingerprint import FingerprintConfig
 from pydub.exceptions import CouldntDecodeError
-from scipy.ndimage import (binary_erosion, generate_binary_structure,
-                           iterate_structure, maximum_filter)
+from scipy.ndimage import (
+    binary_erosion,
+    generate_binary_structure,
+    iterate_structure,
+    maximum_filter,
+)
 
 np.seterr(divide="ignore")
 
@@ -39,7 +43,10 @@ def _fingerprint_worker(
 
         try:
             channel, _ = audalign.filehandler.read(
-                file_path, start_end=config.start_end, sample_rate=config.sample_rate
+                file_path,
+                start_end=config.start_end,
+                sample_rate=config.sample_rate,
+                normalize=config.normalize,
             )
         except FileNotFoundError:
             print(f'"{file_path}" not found')

--- a/audalign/recognizers/visrecognize/visrecognize.py
+++ b/audalign/recognizers/visrecognize/visrecognize.py
@@ -378,7 +378,10 @@ def get_arrays(
         )
     else:
         samples, _ = read(
-            file_path, start_end=start_end, sample_rate=config.sample_rate
+            file_path,
+            start_end=start_end,
+            sample_rate=config.sample_rate,
+            normalize=config.normalize,
         )
     arr2d = fingerprint.fingerprint(samples, config, retspec=True)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def parse_requirements(requirements):
 
 
 PACKAGE_NAME = "audalign"
-PACKAGE_VERSION = "1.2.1"
+PACKAGE_VERSION = "1.2.2"
 SUMMARY = "Audio Alignment and Recognition in Python"
 
 REQUIREMENTS = parse_requirements("requirements.txt")

--- a/tests/test_audalign.py
+++ b/tests/test_audalign.py
@@ -248,6 +248,20 @@ class TestStartEnd:
             start_end=(5, -10),
         )
 
+    def test_no_normalize(self, tmpdir):
+        ad.convert_audio_file(
+            self.test_file,
+            tmpdir.join("test_temp.mp3"),
+            start_end=(5, 10),
+            normalize=False,
+        )
+        ad.write_processed_file(
+            self.test_file,
+            tmpdir.join("test_temp.mp3"),
+            start_end=(5, -10),
+            normalize=False,
+        )
+
     def test_bounds_checks(self):
         try:
             ad.filehandler.read(self.test_file, start_end=(5, 4))


### PR DESCRIPTION
Adds a `normalize` field to BaseConfig that turns off normalization if False. Most audalign functions that don't have a config argument (non recognition/alignment functions) now have a normalize argument. Functions like the `remove_noise_*` or `uniform_level_*` functions did not have a normalize argument added.

Implements #45 