### PR TITLE
Use >= instead of == for dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,12 @@ keywords = [
     "python",
 ]
 dependencies = [
-    "matplotlib==3.8.2",
-    "numpy==1.26.4",
-    "pydub==0.25.1",
-    "scipy==1.12.0",
-    "setuptools==59.6.0",
-    "tqdm==4.66.2",
+    "matplotlib>=3.8.2",
+    "numpy>=1.26.4",
+    "pydub>=0.25.1",
+    "scipy>=1.12.0",
+    "setuptools>=59.6.0",
+    "tqdm>=4.66.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Installing this package is difficult because it requires exact versions of all its dependencies.

It seems to work with the latest version of all its dependencies, so they may as well be changed to >=